### PR TITLE
Link sponsoring packages page

### DIFF
--- a/sponsor-packages.html
+++ b/sponsor-packages.html
@@ -106,7 +106,7 @@ bodytags: with-hero
       </tr>
 
       <tr>
-        <td colspan="2">Mention in TWiRF post</td>
+        <td colspan="2">Mention in <a href="#twirf">TWiRF</a> post</td>
         <td>✔</td>
         <td>✔</td>
         <td>✔</td>
@@ -280,6 +280,9 @@ bodytags: with-hero
     <blockquote id="note-1">Note: all additional sponsorship options can be selected individually, or as add-ons to any of the sponsorship tiers, <strong>with the exception</strong> of the Afterparty Sponsor option which can only be selected as an add-on to any (Bronze...Platinum) sponsorship package.</blockquote>
 
     <blockquote id="note-2">Note: The Platinum sponsorship tier is only available to one sponsor, and is assigned on a first-come-first-serve basis.</blockquote>
+
+    <blockquote id="twirf">TWiRF: This Week in RustFest, the RustFest weekly <a href="https://blog.rustfest.eu" target="_new">blog post</a>.</blockquote>
+
   </section>
 
 </div>

--- a/sponsors.md
+++ b/sponsors.md
@@ -13,15 +13,14 @@ title: Sponsoring
 {% assign media = site.sponsors | where: "group", "media" %}
 
 <div class="popout sponsors">
-  <section>
-    <h1>Sponsors</h1>
-    <hr />
-    <p>
-      RustFest wouldn't be possible without generous support of sponsors.
-      If you want to sponsor this year's RustFest Rome contact us at <a href="mailto:team@rustfest.eu">team@rustfest.eu</a>
-    </p>
-  </section>
+    <section>
+        <h1>Sponsors</h1>
+        <hr />
+        <p>RustFest wouldn't be possible without generous support of sponsors.</p>
+    </section>
 </div>
+
+{% comment %}
 
 <!--
 
@@ -101,12 +100,14 @@ title: Sponsoring
 
 </div>
 
+-->
+{% endcomment %}
 
 <section class="whitewithwheel">
   <h2>Interested in sponsoring us?</h2>
   <br />
   <p>
-    <a class="button" href="mailto:sponsors@rustfest.eu">
+    <a class="button" href="mailto:team@rustfest.eu">
       Get in touch now
     </a>
     <a class="button" href="/sponsors/packages/">
@@ -114,4 +115,3 @@ title: Sponsoring
     </a>
   </p>
 </section>
--->

--- a/sponsors.md
+++ b/sponsors.md
@@ -107,7 +107,7 @@ title: Sponsoring
   <h2>Interested in sponsoring us?</h2>
   <br />
   <p>
-    <a class="button" href="mailto:team@rustfest.eu">
+    <a class="button" href="mailto:sponsors@rustfest.eu">
       Get in touch now
     </a>
     <a class="button" href="/sponsors/packages/">


### PR DESCRIPTION
The "sponsors" page is a bit empty.

I thought we could link the sponsoring packages page.

opinions?